### PR TITLE
Remove hard wraps

### DIFF
--- a/pkg/collection.go
+++ b/pkg/collection.go
@@ -66,7 +66,6 @@ func markdownToHtml(filename string) (string, map[interface{}]interface{}) {
 			parser.WithAutoHeadingID(),
 		),
 		goldmark.WithRendererOptions(
-			html.WithHardWraps(),
 			html.WithXHTML(),
 			html.WithUnsafe(),
 		),


### PR DESCRIPTION
Single newlines in Markdown file will not insert page breaks into HTML